### PR TITLE
added logic for filters in typescript

### DIFF
--- a/src/components/Pages/DataVisualization.vue
+++ b/src/components/Pages/DataVisualization.vue
@@ -131,15 +131,27 @@ export default defineComponent ({
 
             receivedData.value = true;
             if (data.categories.some(a => a == "Engine Speed (rpm)")){
+                filteredLogs = parsedLogs.filter( a=>
+                                                    a.engine_speed >= rpmFilter.value.min && 
+                                                    a.engine_speed <= rpmFilter.value.max
+                                                );
                 if(data.categories.some(fb => fb == "Feedback Knock Correction* (degrees)" || fb == "Feedback Knock Correction (degrees)")){
                     let data = filteredLogs.filter(f => f.feedback_knock_corr != 0).map(a => new ScatterPoint(a.engine_speed, a.feedback_knock_corr, 5));
                     plots.push(new PlotData(data, 'Engine Speed (rpm)', "Feedback Knock Correction (degrees)", "Feedback Knock Correction vs. Engine RPM", "RPM", "FBKC"));
                 }
                 if(data.categories.some(fb => (fb == "Feedback Knock Correction* (degrees)" || fb == "Feedback Knock Correction (degrees)")) && data.categories.some(fl => fl == "Fine Learning Knock Correction (degrees)" || fl == "Fine Learning Knock Correction* (degrees)") && data.categories.some(el => el == "Engine Load (Calculated) (g/rev)" || el == "Engine Load* (g/rev)" || el == "Engine Load (g/rev)")){
+                    filteredLogs = parsedLogs.filter( a=>
+                                                        a.engine_load >= loadFilter.value.min &&
+                                                        a.engine_load <= loadFilter.value.max
+                                                    );  
                     let data = filteredLogs.filter(a => a.feedback_knock_corr  != 0 || a.fine_knock_corr != 0).map(b => new ScatterPoint(b.engine_speed, b.engine_load, (Math.abs(b.feedback_knock_corr + b.fine_knock_corr))*3));
                     plots.push(new PlotData(data, 'Engine Speed (rpm)', 'Engine Load (g/rev)', "Engine Load vs. Engine RPM where Knock Events Occur", "RPM", "LOAD", "TKNOCK", (x: number) => x/-3));
                 }
                 if(data.categories.some(mp => mp == "Manifold Relative Pressure (psi)")){
+                    filteredLogs = parsedLogs.filter( a=>
+                                                        a.boost >= boostFilter.value.min &&
+                                                        a.boost <= boostFilter.value.max
+                                                    );  
                     let data = filteredLogs.map(a => new ScatterPoint(a.engine_speed, a.boost, 5));
                     plots.push(new PlotData(data, 'Engine Speed (rpm)', 'Manifold Relative Pressure (psi)', "Manifold Relative Pressure vs. Engine RPM", "RPM", "PSI"));
                 }

--- a/src/components/Pages/DataVisualization.vue
+++ b/src/components/Pages/DataVisualization.vue
@@ -26,12 +26,13 @@ Remember to:
                         <h6>Engine Speed</h6>
                     </q-badge>
                     <q-range
-                        v-model="rpmFilter"
+                        v-model="selectedValues"
                         :min="0"
                         :max="10000"
                         :step="100"
                         label-always
                     />
+                    <button @click="handleButtonClick()">Get Selected Values</button>
                     <!-- Load Filter-->
                     <q-badge color="primary" class="q-mb-lg">
                         <h6>Engine Load</h6>
@@ -66,100 +67,127 @@ Remember to:
 </template>
 
 <script lang="ts">
-import { Vue, Options } from 'vue-class-component';
 import CSV_Input from '../../components/CSV_Input.vue'
 import DataVisualizationLog from './DataVisualization/dataVisLog';
 import ScatterPoint from './DataVisualization/dataPoint'
 import PlotData from './DataVisualization/plotData';
 import DataVisualizationPlot from './DataVisualization/DataVisualizationPlot.vue'
-
+import { defineComponent } from 'vue';
+import { ref } from 'vue';
+/*
 @Options({
   components: {
     CSV_Input,
     DataVisualizationPlot,
   },
 })
+*/
+export default defineComponent ({
+    components: {
+        CSV_Input,
+        DataVisualizationPlot
+    },
+    setup() {
+        //declare variables and write functions here
+        const title: string = "Data Visualization";
+        let receivedData: boolean = false;
+        let parsedLogs: DataVisualizationLog[] = [];
+        let plots: PlotData[] = [];
+        
+        const selectedValues = ref(
+            {
+                min: 1000,
+                max: 10000
+            }
+        );
+        // filters
+        const rpmFilter = {
+            min: 1000,
+            max: 10000,
+        };
+        const loadFilter = {
+            min: 1.0,
+            max: 100.0,
+        };
+        const boostFilter = {
+            min: 0.0,
+            max: 50.0,
+        };
+        const filters = {
+            rpm: rpmFilter,
+            load: loadFilter,
+            boost: boostFilter,
+        };
+        let filteredLogs: DataVisualizationLog[] = [];
 
-export default class DataVisualization extends Vue {
-    //declare variables and write functions here
-    title: string = "Data Visualization";
-    receivedData: boolean = false;
-    parsedLogs: DataVisualizationLog[] = [];
-    plots: PlotData[] = [];
-    
-    // filters
-    rpmFilter = {
-        min: 1000,
-        max: 10000,
-    };
-    loadFilter = {
-        min: 1.0,
-        max: 100.0,
-    };
-    boostFilter = {
-        min: 0.0,
-        max: 50.0,
-    };
-    filters = {
-        rpm: this.rpmFilter,
-        load: this.loadFilter,
-        boost: this.boostFilter,
-    };
-    rawData = {
-        categories: [],
-        lines: [],
-    }
-    filteredLogs: DataVisualizationLog[] = [];
+        const handleButtonClick = () => {
+            const minValue = selectedValues.value.min;
+            const maxValue = selectedValues.value.max;
+            console.log(minValue, maxValue);
+        }
 
-    buildObjects(data: {categories: string[], lines: string[]}){
-        this.receivedData = false;
-        this.plots.length = 0;
-        data.lines.forEach(line => {
-            if (line && line != ""){
-                let lineData = line.split(',');
-                let log = new DataVisualizationLog(data.categories, lineData);
-                this.parsedLogs.push(log);
-            }
-        })
+        const buildObjects = (data: {categories: string[], lines: string[]}) => {
+            receivedData = false;
+            plots.length = 0;
+            data.lines.forEach(line => {
+                if (line && line != ""){
+                    let lineData = line.split(',');
+                    let log = new DataVisualizationLog(data.categories, lineData);
+                    parsedLogs.push(log);
+                }
+            })
 
-        // filter data
-        this.filteredLogs = this.parsedLogs.filter( a => 
-                                                    a.engine_speed >= this.filters.rpm.min && 
-                                                    a.engine_speed <= this.filters.rpm.max &&
-                                                    a.engine_load >= this.filters.load.min &&
-                                                    a.engine_load <= this.filters.load.max &&
-                                                    a.boost >= this.filters.boost.min &&
-                                                    a.boost <= this.filters.boost.max
-                                                );
+            // filter data
+            filteredLogs = parsedLogs.filter( a => 
+                                                        a.engine_speed >= filters.rpm.min && 
+                                                        a.engine_speed <= filters.rpm.max &&
+                                                        a.engine_load >= filters.load.min &&
+                                                        a.engine_load <= filters.load.max &&
+                                                        a.boost >= filters.boost.min &&
+                                                        a.boost <= filters.boost.max
+                                                    );
 
-        this.receivedData = true;
-        if (data.categories.some(a => a == "Engine Speed (rpm)")){
-            if(data.categories.some(fb => fb == "Feedback Knock Correction* (degrees)" || fb == "Feedback Knock Correction (degrees)")){
-                let data = this.filteredLogs.filter(f => f.feedback_knock_corr != 0).map(a => new ScatterPoint(a.engine_speed, a.feedback_knock_corr, 5));
-                this.plots.push(new PlotData(data, 'Engine Speed (rpm)', "Feedback Knock Correction (degrees)", "Feedback Knock Correction vs. Engine RPM", "RPM", "FBKC"));
-            }
-            if(data.categories.some(fb => (fb == "Feedback Knock Correction* (degrees)" || fb == "Feedback Knock Correction (degrees)")) && data.categories.some(fl => fl == "Fine Learning Knock Correction (degrees)" || fl == "Fine Learning Knock Correction* (degrees)") && data.categories.some(el => el == "Engine Load (Calculated) (g/rev)" || el == "Engine Load* (g/rev)" || el == "Engine Load (g/rev)")){
-                let data = this.filteredLogs.filter(a => a.feedback_knock_corr  != 0 || a.fine_knock_corr != 0).map(b => new ScatterPoint(b.engine_speed, b.engine_load, (Math.abs(b.feedback_knock_corr + b.fine_knock_corr))*3));
-                this.plots.push(new PlotData(data, 'Engine Speed (rpm)', 'Engine Load (g/rev)', "Engine Load vs. Engine RPM where Knock Events Occur", "RPM", "LOAD", "TKNOCK", (x: number) => x/-3));
-            }
-            if(data.categories.some(mp => mp == "Manifold Relative Pressure (psi)")){
-                let data = this.filteredLogs.map(a => new ScatterPoint(a.engine_speed, a.boost, 5));
-                this.plots.push(new PlotData(data, 'Engine Speed (rpm)', 'Manifold Relative Pressure (psi)', "Manifold Relative Pressure vs. Engine RPM", "RPM", "PSI"));
-            }
-            if(data.categories.some(wg => wg == "Primary Wastegate Duty Cycle (%)")){
-                let data = this.filteredLogs.map(a => new ScatterPoint(a.engine_speed, a.wastegate_duty, 5));
-                this.plots.push(new PlotData(data, 'Engine Speed (rpm)', "Primary Wastegate Duty Cycle (%)", "Wastegate Duty Cycle vs. Engine RPM", "RPM", "WGDC"));
-            }
-            if(data.categories.some(aem => aem == "AEM UEGO Wideband [9600 baud] (AFR Gasoline)")){
-                let data = this.filteredLogs.map(a => new ScatterPoint(a.engine_speed, a.wideband_afr, 5));
-                this.plots.push(new PlotData(data, 'Engine Speed (rpm)', "AEM UEGO Wideband [9600 baud] (AFR Gasoline)", "Wideband AFR vs. Engine RPM", "RPM", "AFR"));
+            receivedData = true;
+            if (data.categories.some(a => a == "Engine Speed (rpm)")){
+                if(data.categories.some(fb => fb == "Feedback Knock Correction* (degrees)" || fb == "Feedback Knock Correction (degrees)")){
+                    let data = filteredLogs.filter(f => f.feedback_knock_corr != 0).map(a => new ScatterPoint(a.engine_speed, a.feedback_knock_corr, 5));
+                    plots.push(new PlotData(data, 'Engine Speed (rpm)', "Feedback Knock Correction (degrees)", "Feedback Knock Correction vs. Engine RPM", "RPM", "FBKC"));
+                }
+                if(data.categories.some(fb => (fb == "Feedback Knock Correction* (degrees)" || fb == "Feedback Knock Correction (degrees)")) && data.categories.some(fl => fl == "Fine Learning Knock Correction (degrees)" || fl == "Fine Learning Knock Correction* (degrees)") && data.categories.some(el => el == "Engine Load (Calculated) (g/rev)" || el == "Engine Load* (g/rev)" || el == "Engine Load (g/rev)")){
+                    let data = filteredLogs.filter(a => a.feedback_knock_corr  != 0 || a.fine_knock_corr != 0).map(b => new ScatterPoint(b.engine_speed, b.engine_load, (Math.abs(b.feedback_knock_corr + b.fine_knock_corr))*3));
+                    plots.push(new PlotData(data, 'Engine Speed (rpm)', 'Engine Load (g/rev)', "Engine Load vs. Engine RPM where Knock Events Occur", "RPM", "LOAD", "TKNOCK", (x: number) => x/-3));
+                }
+                if(data.categories.some(mp => mp == "Manifold Relative Pressure (psi)")){
+                    let data = filteredLogs.map(a => new ScatterPoint(a.engine_speed, a.boost, 5));
+                    plots.push(new PlotData(data, 'Engine Speed (rpm)', 'Manifold Relative Pressure (psi)', "Manifold Relative Pressure vs. Engine RPM", "RPM", "PSI"));
+                }
+                if(data.categories.some(wg => wg == "Primary Wastegate Duty Cycle (%)")){
+                    let data = filteredLogs.map(a => new ScatterPoint(a.engine_speed, a.wastegate_duty, 5));
+                    plots.push(new PlotData(data, 'Engine Speed (rpm)', "Primary Wastegate Duty Cycle (%)", "Wastegate Duty Cycle vs. Engine RPM", "RPM", "WGDC"));
+                }
+                if(data.categories.some(aem => aem == "AEM UEGO Wideband [9600 baud] (AFR Gasoline)")){
+                    let data = filteredLogs.map(a => new ScatterPoint(a.engine_speed, a.wideband_afr, 5));
+                    plots.push(new PlotData(data, 'Engine Speed (rpm)', "AEM UEGO Wideband [9600 baud] (AFR Gasoline)", "Wideband AFR vs. Engine RPM", "RPM", "AFR"));
+                }
             }
         }
-        //if (this.)
-        //this.apiRequest(logs);
+        // return any methods or variables that need to be accessed outside
+        return {
+            // methods
+            buildObjects,
+            handleButtonClick,
+
+            // variables
+            selectedValues,
+            receivedData,
+            title,
+            plots,
+            loadFilter,
+            boostFilter,
+        }
     }
 
-}
+})
 
 </script>
 

--- a/src/components/Pages/DataVisualization.vue
+++ b/src/components/Pages/DataVisualization.vue
@@ -119,16 +119,6 @@ export default defineComponent ({
                 }
             })
 
-            // filter data
-            filteredLogs = parsedLogs.filter( a => 
-                                                a.engine_speed >= rpmFilter.value.min && 
-                                                a.engine_speed <= rpmFilter.value.max &&
-                                                a.engine_load >= loadFilter.value.min &&
-                                                a.engine_load <= loadFilter.value.max &&
-                                                a.boost >= boostFilter.value.min &&
-                                                a.boost <= boostFilter.value.max
-                                            );
-
             receivedData.value = true;
             if (data.categories.some(a => a == "Engine Speed (rpm)")){
                 filteredLogs = parsedLogs.filter( a=>

--- a/src/components/Pages/DataVisualization.vue
+++ b/src/components/Pages/DataVisualization.vue
@@ -60,7 +60,7 @@ Remember to:
     <br>
     <br>
     <CSV_Input @csvProcessed="buildObjects($event)" />
-    <div v-if="receivedData.value">
+    <div v-if="receivedData.value" :key="key">
         <!-- Using index as unique id (key) -->
         <DataVisualizationPlot v-for="(plot, index) of plots" v-bind:key="index"  :plot_data="plot"/>
     </div>
@@ -72,7 +72,7 @@ import DataVisualizationLog from './DataVisualization/dataVisLog';
 import ScatterPoint from './DataVisualization/dataPoint'
 import PlotData from './DataVisualization/plotData';
 import DataVisualizationPlot from './DataVisualization/DataVisualizationPlot.vue'
-import { defineComponent , reactive } from 'vue';
+import { defineComponent , reactive, watch } from 'vue';
 import { ref } from 'vue';
 
 export default defineComponent ({
@@ -83,7 +83,7 @@ export default defineComponent ({
     setup() {
         //declare variables and write functions here
         const title: string = "Data Visualization";
-        const receivedData = reactive({value: false}); // reactive is a new vue3 feature that keeps stuff constantly updated
+        const receivedData = reactive({value: false}); // reactive is a new vue3 feature that creates a reactive reference to an object
         let parsedLogs: DataVisualizationLog[] = [];
         let plots = reactive<PlotData[]> ([]);
         
@@ -154,6 +154,16 @@ export default defineComponent ({
             }
             console.log(plots);
         }
+
+        const key = ref(0);
+        watch(plots, () => 
+            {
+                // reload the DataVisualizationPlot component, when plots changes
+                key.value += 1; // when vue detects that the key changes, it will reload that component
+            },
+            {deep: true} // enables deep watching, which watches the properties of PlotData for changes
+        )
+
         // return any methods or variables that need to be accessed outside the function
         return {
             // methods
@@ -166,6 +176,7 @@ export default defineComponent ({
             rpmFilter,
             loadFilter,
             boostFilter,
+            key,
         }
     }
 

--- a/src/components/Pages/DataVisualization.vue
+++ b/src/components/Pages/DataVisualization.vue
@@ -26,13 +26,12 @@ Remember to:
                         <h6>Engine Speed</h6>
                     </q-badge>
                     <q-range
-                        v-model="selectedValues"
+                        v-model="rpmFilter"
                         :min="0"
                         :max="10000"
                         :step="100"
                         label-always
                     />
-                    <button @click="handleButtonClick()">Get Selected Values</button>
                     <!-- Load Filter-->
                     <q-badge color="primary" class="q-mb-lg">
                         <h6>Engine Load</h6>
@@ -94,37 +93,26 @@ export default defineComponent ({
         let parsedLogs: DataVisualizationLog[] = [];
         let plots: PlotData[] = [];
         
-        const selectedValues = ref(
+        // filters
+        const rpmFilter = ref(
             {
                 min: 1000,
                 max: 10000
             }
         );
-        // filters
-        const rpmFilter = {
-            min: 1000,
-            max: 10000,
-        };
-        const loadFilter = {
-            min: 1.0,
-            max: 100.0,
-        };
-        const boostFilter = {
-            min: 0.0,
-            max: 50.0,
-        };
-        const filters = {
-            rpm: rpmFilter,
-            load: loadFilter,
-            boost: boostFilter,
-        };
+        const loadFilter = ref(
+            {
+                min: 0.0,
+                max: 100.0
+            }
+        );
+        const boostFilter = ref(
+            {
+                min: 0.0,
+                max: 50.0
+            }
+        );
         let filteredLogs: DataVisualizationLog[] = [];
-
-        const handleButtonClick = () => {
-            const minValue = selectedValues.value.min;
-            const maxValue = selectedValues.value.max;
-            console.log(minValue, maxValue);
-        }
 
         const buildObjects = (data: {categories: string[], lines: string[]}) => {
             receivedData = false;
@@ -139,12 +127,12 @@ export default defineComponent ({
 
             // filter data
             filteredLogs = parsedLogs.filter( a => 
-                                                        a.engine_speed >= filters.rpm.min && 
-                                                        a.engine_speed <= filters.rpm.max &&
-                                                        a.engine_load >= filters.load.min &&
-                                                        a.engine_load <= filters.load.max &&
-                                                        a.boost >= filters.boost.min &&
-                                                        a.boost <= filters.boost.max
+                                                        a.engine_speed >= rpmFilter.value.min && 
+                                                        a.engine_speed <= rpmFilter.value.max &&
+                                                        a.engine_load >= loadFilter.value.min &&
+                                                        a.engine_load <= loadFilter.value.max &&
+                                                        a.boost >= boostFilter.value.min &&
+                                                        a.boost <= boostFilter.value.max
                                                     );
 
             receivedData = true;
@@ -175,13 +163,12 @@ export default defineComponent ({
         return {
             // methods
             buildObjects,
-            handleButtonClick,
 
             // variables
-            selectedValues,
             receivedData,
             title,
             plots,
+            rpmFilter,
             loadFilter,
             boostFilter,
         }

--- a/src/components/Pages/DataVisualization.vue
+++ b/src/components/Pages/DataVisualization.vue
@@ -155,9 +155,22 @@ export default defineComponent ({
                     plots.push(new PlotData(data, 'Engine Speed (rpm)', "AEM UEGO Wideband [9600 baud] (AFR Gasoline)", "Wideband AFR vs. Engine RPM", "RPM", "AFR"));
                 }
             }
+            clearParsedLogs();
             key.value += 1;
             console.log(plots);
         }
+
+        // remove data stored in ```parsedLogs```
+        /*
+            Idea: 
+                If a user switches from one log file to another, the data from the original log file stayed saved in parsedLogs
+                If parsedLogs is never cleared a user will see overlapping data from both logs when charts are reloaded
+                Therefore parsedLogs should be cleared each time buildObjects() is run
+        */
+        const clearParsedLogs = () => {
+            parsedLogs.length = 0;
+        }
+
 
         /*
         const key = ref(0);

--- a/src/components/Pages/DataVisualization.vue
+++ b/src/components/Pages/DataVisualization.vue
@@ -60,8 +60,7 @@ Remember to:
     <br>
     <br>
     <CSV_Input @csvProcessed="buildObjects($event)" />
-    <div v-if="receivedData.value" :key="key">
-        <!-- Using index as unique id (key) -->
+    <div v-if="receivedData.value" :key="plotsIndex">
         <DataVisualizationPlot v-for="(plot, index) of plots" v-bind:key="index"  :plot_data="plot"/>
     </div>
 </template>
@@ -72,7 +71,7 @@ import DataVisualizationLog from './DataVisualization/dataVisLog';
 import ScatterPoint from './DataVisualization/dataPoint'
 import PlotData from './DataVisualization/plotData';
 import DataVisualizationPlot from './DataVisualization/DataVisualizationPlot.vue'
-import { defineComponent , reactive/*, watch*/ } from 'vue';
+import { defineComponent , reactive } from 'vue';
 import { ref } from 'vue';
 
 export default defineComponent ({
@@ -81,7 +80,7 @@ export default defineComponent ({
         DataVisualizationPlot
     },
     setup() {
-        //declare variables and write functions here
+        // declare variables and write functions here
         const title: string = "Data Visualization";
         const receivedData = reactive({value: false}); // reactive is a new vue3 feature that creates a reactive reference to an object
         let parsedLogs: DataVisualizationLog[] = [];
@@ -107,8 +106,9 @@ export default defineComponent ({
             }
         );
         let filteredLogs: DataVisualizationLog[] = [];
-        const key = ref(0);
+        const plotsIndex = ref(0); // used for reloading plots
 
+        // runs everytime a user clicks on the parse csv button
         const buildObjects = (data: {categories: string[], lines: string[]}) => {
             receivedData.value = false;
             plots.length = 0; // clear the reactive list
@@ -156,7 +156,7 @@ export default defineComponent ({
                 }
             }
             clearParsedLogs();
-            key.value += 1;
+            plotsIndex.value += 1;
             console.log(plots);
         }
 
@@ -171,18 +171,6 @@ export default defineComponent ({
             parsedLogs.length = 0;
         }
 
-
-        /*
-        const key = ref(0);
-        watch(plots, () => 
-            {
-                // reload the DataVisualizationPlot component, when plots changes
-                key.value += 1; // when vue detects that the key changes, it will reload that component
-            },
-            {deep: true} // enables deep watching, which watches the properties of PlotData for changes
-        )
-        */
-
         // return any methods or variables that need to be accessed outside the function
         return {
             // methods
@@ -192,10 +180,10 @@ export default defineComponent ({
             receivedData,
             title,
             plots,
+            plotsIndex,
             rpmFilter,
             loadFilter,
             boostFilter,
-            key,
         }
     }
 

--- a/src/components/Pages/DataVisualization.vue
+++ b/src/components/Pages/DataVisualization.vue
@@ -12,6 +12,23 @@ Remember to:
     <img v-if="!receivedData" alt="Subaru Legacy B4" height="333" width="500" src="../../assets/carpic_3.jpg">
     <br>
     <br>
+    <q-card class="my-card" bordered
+            style="width:500px;">
+        <q-card-section>
+            <div class="text-h6 text-grey-8">
+                Filters
+            </div>
+        </q-card-section>
+        <q-separator/>
+        <q-card-section>
+            Hello there
+        </q-card-section>
+        <q-card-actions align="center">
+            <q-btn label="Go Somewhere" class="text-capitalize q-ma-sm" color="indigo-7"/>
+        </q-card-actions>
+    </q-card>
+    <br>
+    <br>
     <CSV_Input @csvProcessed="buildObjects($event)" />
     <div v-if="receivedData">
         <DataVisualizationPlot v-for="plot of plots" v-bind:key="plot"  :plot_data="plot"/>

--- a/src/components/Pages/DataVisualization.vue
+++ b/src/components/Pages/DataVisualization.vue
@@ -72,7 +72,7 @@ import DataVisualizationLog from './DataVisualization/dataVisLog';
 import ScatterPoint from './DataVisualization/dataPoint'
 import PlotData from './DataVisualization/plotData';
 import DataVisualizationPlot from './DataVisualization/DataVisualizationPlot.vue'
-import { defineComponent , reactive, watch } from 'vue';
+import { defineComponent , reactive/*, watch*/ } from 'vue';
 import { ref } from 'vue';
 
 export default defineComponent ({
@@ -107,10 +107,11 @@ export default defineComponent ({
             }
         );
         let filteredLogs: DataVisualizationLog[] = [];
+        const key = ref(0);
 
         const buildObjects = (data: {categories: string[], lines: string[]}) => {
             receivedData.value = false;
-            plots.length = 0;
+            plots.length = 0; // clear the reactive list
             data.lines.forEach(line => {
                 if (line && line != ""){
                     let lineData = line.split(',');
@@ -154,9 +155,11 @@ export default defineComponent ({
                     plots.push(new PlotData(data, 'Engine Speed (rpm)', "AEM UEGO Wideband [9600 baud] (AFR Gasoline)", "Wideband AFR vs. Engine RPM", "RPM", "AFR"));
                 }
             }
+            key.value += 1;
             console.log(plots);
         }
 
+        /*
         const key = ref(0);
         watch(plots, () => 
             {
@@ -165,6 +168,7 @@ export default defineComponent ({
             },
             {deep: true} // enables deep watching, which watches the properties of PlotData for changes
         )
+        */
 
         // return any methods or variables that need to be accessed outside the function
         return {

--- a/src/components/Pages/DataVisualization.vue
+++ b/src/components/Pages/DataVisualization.vue
@@ -12,30 +12,57 @@ Remember to:
     <img v-if="!receivedData" alt="Subaru Legacy B4" height="333" width="500" src="../../assets/carpic_3.jpg">
     <br>
     <br>
-    <q-card class="my-card" bordered
-            style="width:500px;">
-        <q-card-section>
-            <div class="text-h6 text-grey-8">
-                Filters
-            </div>
-        </q-card-section>
-        <q-separator/>
-        <q-card-section>
-            Hello there
-        </q-card-section>
-        <q-card-actions align="center">
-            <q-btn label="Go Somewhere" class="text-capitalize q-ma-sm" color="indigo-7"/>
-        </q-card-actions>
-    </q-card>
+        <q-card class="my-card" bordered>
+            <q-card-section>
+                <div class="text-h6 text-grey-8">
+                    Filters
+                </div>
+            </q-card-section>
+            <q-separator/>
+            <q-card-actions align="center">
+                <div class="q-pa-md">
+                    <!-- RPM Filter-->
+                    <q-badge color="primary" class="q-mb-lg">
+                        <h6>Engine Speed</h6>
+                    </q-badge>
+                    <q-range
+                        v-model="rpmFilter"
+                        :min="0"
+                        :max="10000"
+                        :step="100"
+                        label-always
+                    />
+                    <!-- Load Filter-->
+                    <q-badge color="primary" class="q-mb-lg">
+                        <h6>Engine Load</h6>
+                    </q-badge>
+                    <q-range
+                        v-model="loadFilter"
+                        :min="0.0"
+                        :max="10.0"
+                        :step="0.1"
+                        label-always
+                    />
+                    <!-- Boost Filter-->
+                    <q-badge color="primary" class="q-mb-lg">
+                        <h6>Boost</h6>
+                    </q-badge>
+                    <q-range
+                        v-model="boostFilter"
+                        :min="-50.0"
+                        :max="50.0"
+                        :step="0.1"
+                        label-always
+                    />
+                </div>
+            </q-card-actions>
+        </q-card>
     <br>
     <br>
     <CSV_Input @csvProcessed="buildObjects($event)" />
     <div v-if="receivedData">
         <DataVisualizationPlot v-for="plot of plots" v-bind:key="plot"  :plot_data="plot"/>
     </div>
-    
-
-
 </template>
 
 <script lang="ts">
@@ -60,12 +87,28 @@ export default class DataVisualization extends Vue {
     parsedLogs: DataVisualizationLog[] = [];
     plots: PlotData[] = [];
     
-    filters = {
-        rpm: [0,100000],
-        load: [1.0, 100],
-        boost: [0.0,1000],
-        // throttle: [0,100],
+    // filters
+    rpmFilter = {
+        min: 1000,
+        max: 10000,
     };
+    loadFilter = {
+        min: 1.0,
+        max: 100.0,
+    };
+    boostFilter = {
+        min: 0.0,
+        max: 50.0,
+    };
+    filters = {
+        rpm: this.rpmFilter,
+        load: this.loadFilter,
+        boost: this.boostFilter,
+    };
+    rawData = {
+        categories: [],
+        lines: [],
+    }
     filteredLogs: DataVisualizationLog[] = [];
 
     buildObjects(data: {categories: string[], lines: string[]}){
@@ -81,12 +124,12 @@ export default class DataVisualization extends Vue {
 
         // filter data
         this.filteredLogs = this.parsedLogs.filter( a => 
-                                                    a.engine_speed >= this.filters.rpm[0] && 
-                                                    a.engine_speed <= this.filters.rpm[1] &&
-                                                    a.engine_load >= this.filters.load[0] &&
-                                                    a.engine_load <= this.filters.load[1] &&
-                                                    a.boost >= this.filters.boost[0] &&
-                                                    a.boost <= this.filters.boost[1]
+                                                    a.engine_speed >= this.filters.rpm.min && 
+                                                    a.engine_speed <= this.filters.rpm.max &&
+                                                    a.engine_load >= this.filters.load.min &&
+                                                    a.engine_load <= this.filters.load.max &&
+                                                    a.boost >= this.filters.boost.min &&
+                                                    a.boost <= this.filters.boost.max
                                                 );
 
         this.receivedData = true;

--- a/src/components/Pages/DataVisualization/DataVisualizationPlot.vue
+++ b/src/components/Pages/DataVisualization/DataVisualizationPlot.vue
@@ -14,7 +14,6 @@ Remember to:
 <script lang="ts">
 //Just regular TS here...
 
-import { Vue, Options } from 'vue-class-component';
 import {
   Chart as ChartJS,
   LinearScale,
@@ -22,33 +21,40 @@ import {
   LineElement,
   Tooltip,
   Legend,
-Title
+  Title
 } from 'chart.js'
 import { Bubble } from 'vue-chartjs'
 import PlotData from './plotData'
-import { Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
 ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend, Title)
 
-@Options({
-  components: {
-    Bubble,
-  },
-})
-
-
-
-export default class DataVisualizationPlot extends Vue {
-    @Prop({default: [], required: true}) plot_data!: PlotData;
-
-    data() {
+export default defineComponent ({
+    name: "DataVisualizationPlot", 
+    components: {
+        Bubble
+    },
+    props: {
+        plot_data: {
+            type: Object as () => PlotData,
+            required: true
+        }
+    },
+    data(props) {
+        const getTooltip = (index: number) => {
+            if(props.plot_data.r_abbrev != null){
+                return props.plot_data.x_abbrev + ': ' + props.plot_data.data[index].x + ' ' + props.plot_data.y_abbrev + ': ' + props.plot_data.data[index].y + ' ' + props.plot_data.r_abbrev + ': ' + props.plot_data.r_logic(props.plot_data.data[index].r);
+            }else{
+                return props.plot_data.x_abbrev + ': ' + props.plot_data.data[index].x + ' ' + props.plot_data.y_abbrev + ': ' + props.plot_data.data[index].y;
+            }
+        }
         return {
             data: {
                 datasets: [
                     { 
                         label: 'Data Point',
                         //color: '#ff6384',
-                        data: this.plot_data.data
+                        data: props.plot_data.data
                     }
                 ],
             },
@@ -56,7 +62,7 @@ export default class DataVisualizationPlot extends Vue {
                 plugins: {
                     title: {
                         display: true,
-                        text: this.plot_data.title,
+                        text: props.plot_data.title,
                         padding: {
                             top: 10,
                             bottom: 10
@@ -66,7 +72,7 @@ export default class DataVisualizationPlot extends Vue {
                         callbacks: {
                             label: (ctx: any) => {
                                 //return 'RPM: ' + this.plot_data.data[ctx.dataIndex].x + '\nLOAD: ' + this.plot_data.data[ctx.dataIndex].y + '\nKNOCK: ' + (this.plot_data.data[ctx.dataIndex].r / -3);
-                                return this.getTooltip(ctx.dataIndex);
+                                return getTooltip(ctx.dataIndex);
                             }
                         }
                     },
@@ -89,14 +95,14 @@ export default class DataVisualizationPlot extends Vue {
                     x: 
                         {
                             title: {
-                                text: this.plot_data.x_label,
+                                text: props.plot_data.x_label,
                                 display: true
                             }
                         },
                     y: 
                         {
                             title: {
-                                text: this.plot_data.y_label,
+                                text: props.plot_data.y_label,
                                 display: true
                             }
                         }
@@ -112,16 +118,7 @@ export default class DataVisualizationPlot extends Vue {
             }
         }
     }
-
-  getTooltip(index: number){
-    if(this.plot_data.r_abbrev != null){
-        return this.plot_data.x_abbrev + ': ' + this.plot_data.data[index].x + ' ' + this.plot_data.y_abbrev + ': ' + this.plot_data.data[index].y + ' ' + this.plot_data.r_abbrev + ': ' + this.plot_data.r_logic(this.plot_data.data[index].r);
-    }else{
-        return this.plot_data.x_abbrev + ': ' + this.plot_data.data[index].x + ' ' + this.plot_data.y_abbrev + ': ' + this.plot_data.data[index].y;
-    }
-  }
-
-}
+})
 
 </script>
 

--- a/src/components/Pages/DataVisualization/DataVisualizationPlot.vue
+++ b/src/components/Pages/DataVisualization/DataVisualizationPlot.vue
@@ -25,7 +25,7 @@ import {
 } from 'chart.js'
 import { Bubble } from 'vue-chartjs'
 import PlotData from './plotData'
-import { defineComponent } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
 ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend, Title)
 
@@ -36,18 +36,18 @@ export default defineComponent ({
     },
     props: {
         plot_data: {
-            type: Object as () => PlotData,
+            type: Object as PropType<PlotData>,
             required: true
         }
     },
-    data(props) {
+    setup(props) {
         const getTooltip = (index: number) => {
             if(props.plot_data.r_abbrev != null){
                 return props.plot_data.x_abbrev + ': ' + props.plot_data.data[index].x + ' ' + props.plot_data.y_abbrev + ': ' + props.plot_data.data[index].y + ' ' + props.plot_data.r_abbrev + ': ' + props.plot_data.r_logic(props.plot_data.data[index].r);
             }else{
                 return props.plot_data.x_abbrev + ': ' + props.plot_data.data[index].x + ' ' + props.plot_data.y_abbrev + ': ' + props.plot_data.data[index].y;
             }
-        }
+        };
         return {
             data: {
                 datasets: [


### PR DESCRIPTION
# Allow users to filter data
* For each table or globally, have filters for cutting out unnecessary data
* Example filters: rpm | load | manifold relative pressure | throttle position 

# Implementation
* Used the defineComponent Vue3 which is the newer style of making components in typescript: https://vuejs.org/guide/typescript/overview.html#general-usage-notes
* Implemented reactivity on ```plots``` and ```recievedData``` using both the reactive<> and ref() types:
![image](https://user-images.githubusercontent.com/75449819/219960001-2c9c8571-8b69-4876-a653-f2f2a5797a0b.png)
https://vuejs.org/guide/essentials/reactivity-fundamentals.html
* Added a ''watcher' which watches for changes in the ```plots``` variable. If detected, charts are destroyed and reloaded. This is used to detect changes in filters or data. 
![image](https://user-images.githubusercontent.com/75449819/219959901-463d794d-83ba-4407-8ddd-0a1e2c5fbd80.png)
![image](https://user-images.githubusercontent.com/75449819/219959935-a728b434-e975-49d7-a57b-d78c2590f346.png)
https://vuejs.org/guide/essentials/watchers.html