### PR TITLE
made filters reactive

### DIFF
--- a/src/components/Pages/DataVisualization.vue
+++ b/src/components/Pages/DataVisualization.vue
@@ -10,56 +10,69 @@ Remember to:
 <template>
     <h3>{{title}}</h3>
     <img v-if="!receivedData" alt="Subaru Legacy B4" height="333" width="500" src="../../assets/carpic_3.jpg">
-    <br>
-    <br>
-        <q-card class="my-card" bordered>
-            <q-card-section>
-                <div class="text-h6 text-grey-8">
-                    Filters
-                </div>
-            </q-card-section>
-            <q-separator/>
-            <q-card-actions align="center">
-                <div class="q-pa-md">
-                    <!-- RPM Filter-->
-                    <q-badge color="primary" class="q-mb-lg">
-                        <h6>Engine Speed</h6>
-                    </q-badge>
-                    <q-range
-                        v-model="rpmFilter"
-                        :min="0"
-                        :max="10000"
-                        :step="100"
-                        label-always
-                    />
-                    <!-- Load Filter-->
-                    <q-badge color="primary" class="q-mb-lg">
-                        <h6>Engine Load</h6>
-                    </q-badge>
-                    <q-range
-                        v-model="loadFilter"
-                        :min="0.0"
-                        :max="10.0"
-                        :step="0.1"
-                        label-always
-                    />
-                    <!-- Boost Filter-->
-                    <q-badge color="primary" class="q-mb-lg">
-                        <h6>Boost</h6>
-                    </q-badge>
-                    <q-range
-                        v-model="boostFilter"
-                        :min="-50.0"
-                        :max="50.0"
-                        :step="0.1"
-                        label-always
-                    />
-                </div>
-            </q-card-actions>
-        </q-card>
-    <br>
-    <br>
     <CSV_Input @csvProcessed="buildObjects($event)" />
+    <br>
+    <br>
+        <div v-if="receivedData.value" style="padding-left: 10%; padding-right: 10%">
+            <q-card class="my-card" bordered>
+                <q-card-section>
+                    <div class="text-h6 text-grey-8">
+                        Filters
+                    </div>
+                </q-card-section>
+                <q-separator/>
+                <q-card-actions align="center">
+                    <div class="q-pa-md">
+                        <!-- RPM Filter-->
+                        <div v-if="dataInfo.rpmFilterEnabled">
+                            <q-badge color="primary" class="q-mb-lg">
+                            <h6>Engine Speed</h6>
+                            </q-badge>
+                            <q-range
+                                v-model="rpmFilter"
+                                :min="0"
+                                :max="10000"
+                                :step="100"
+                                label-always
+                                v-on:change="filterLogs"
+                            />
+                        </div>
+                        <!-- Load Filter-->
+                        <div v-if="dataInfo.loadFilterEnabled">
+                            <q-badge color="primary" class="q-mb-lg">
+                            <h6>Engine Load</h6>
+                            </q-badge>
+                            <q-range
+                                v-model="loadFilter"
+                                :min="0.0"
+                                :max="10.0"
+                                :step="0.1"
+                                label-always
+                                v-on:change="filterLogs"
+                            />
+                        </div>
+                        <!-- Boost Filter-->
+                        <div v-if="dataInfo.boostFilterEnabled">
+                            <q-badge color="primary" class="q-mb-lg">
+                            <h6>Boost</h6>
+                            </q-badge>
+                            <q-range
+                                v-model="boostFilter"
+                                :min="-50.0"
+                                :max="50.0"
+                                :step="0.1"
+                                label-always
+                                v-on:change="filterLogs"
+                            />
+                        </div>
+                        
+                    </div>
+                </q-card-actions>
+            </q-card>
+        </div>
+    <br>
+    <h6>Total Data Points Shown: {{dataInfo.numDataPointsShown}}</h6>
+    <br>
     <div v-if="receivedData.value" :key="plotsIndex">
         <DataVisualizationPlot v-for="(plot, index) of plots" v-bind:key="index"  :plot_data="plot"/>
     </div>
@@ -83,7 +96,14 @@ export default defineComponent ({
         // declare variables and write functions here
         const title: string = "Data Visualization";
         const receivedData = reactive({value: false}); // reactive is a new vue3 feature that creates a reactive reference to an object
+        let dataInfo = reactive({
+            numDataPointsShown: 0,
+            rpmFilterEnabled: false,
+            loadFilterEnabled: false,
+            boostFilterEnabled: false,
+        })
         let parsedLogs: DataVisualizationLog[] = [];
+        let categories: string[];
         let plots = reactive<PlotData[]> ([]);
         
         // filters
@@ -110,8 +130,11 @@ export default defineComponent ({
 
         // runs everytime a user clicks on the parse csv button
         const buildObjects = (data: {categories: string[], lines: string[]}) => {
+            clearParsedLogs();
             receivedData.value = false;
-            plots.length = 0; // clear the reactive list
+
+            categories = data.categories;
+            //construct parsed logs array
             data.lines.forEach(line => {
                 if (line && line != ""){
                     let lineData = line.split(',');
@@ -119,45 +142,63 @@ export default defineComponent ({
                     parsedLogs.push(log);
                 }
             })
+            filterLogs();
+
+        }
+
+        const filterLogs = () => {
+            plots.length = 0; // clear the reactive list
+            filteredLogs = parsedLogs;
+            if (categories.some(a => a == "Engine Speed (rpm)")) {
+                dataInfo.rpmFilterEnabled = true;
+                filteredLogs = filteredLogs.filter(a=> a.engine_speed >= rpmFilter.value.min && a.engine_speed <= rpmFilter.value.max);
+            }else{
+                dataInfo.rpmFilterEnabled = false;
+            }
+            if(categories.some(el => el == "Engine Load (Calculated) (g/rev)" || el == "Engine Load* (g/rev)" || el == "Engine Load (g/rev)")){
+                dataInfo.loadFilterEnabled = true;
+                filteredLogs = filteredLogs.filter(a=> a.engine_load >= loadFilter.value.min && a.engine_load <= loadFilter.value.max);  
+            }else{
+                dataInfo.loadFilterEnabled = false;
+            }
+            if(categories.some(mp => mp == "Manifold Relative Pressure (psi)")){
+                dataInfo.boostFilterEnabled = true;
+                filteredLogs = filteredLogs.filter(a=> a.boost >= boostFilter.value.min && a.boost <= boostFilter.value.max);  
+            }
+            else{
+                dataInfo.boostFilterEnabled = false;
+            }
+            dataInfo.numDataPointsShown = filteredLogs.length;
+            generatePlots();
+        }
+
+        const generatePlots = () => {
 
             receivedData.value = true;
-            if (data.categories.some(a => a == "Engine Speed (rpm)")){
-                filteredLogs = parsedLogs.filter( a=>
-                                                    a.engine_speed >= rpmFilter.value.min && 
-                                                    a.engine_speed <= rpmFilter.value.max
-                                                );
-                if(data.categories.some(fb => fb == "Feedback Knock Correction* (degrees)" || fb == "Feedback Knock Correction (degrees)")){
+            if (categories.some(a => a == "Engine Speed (rpm)")){
+                if(categories.some(fb => fb == "Feedback Knock Correction* (degrees)" || fb == "Feedback Knock Correction (degrees)")){
                     let data = filteredLogs.filter(f => f.feedback_knock_corr != 0).map(a => new ScatterPoint(a.engine_speed, a.feedback_knock_corr, 5));
                     plots.push(new PlotData(data, 'Engine Speed (rpm)', "Feedback Knock Correction (degrees)", "Feedback Knock Correction vs. Engine RPM", "RPM", "FBKC"));
                 }
-                if(data.categories.some(fb => (fb == "Feedback Knock Correction* (degrees)" || fb == "Feedback Knock Correction (degrees)")) && data.categories.some(fl => fl == "Fine Learning Knock Correction (degrees)" || fl == "Fine Learning Knock Correction* (degrees)") && data.categories.some(el => el == "Engine Load (Calculated) (g/rev)" || el == "Engine Load* (g/rev)" || el == "Engine Load (g/rev)")){
-                    filteredLogs = parsedLogs.filter( a=>
-                                                        a.engine_load >= loadFilter.value.min &&
-                                                        a.engine_load <= loadFilter.value.max
-                                                    );  
+                if(categories.some(fb => (fb == "Feedback Knock Correction* (degrees)" || fb == "Feedback Knock Correction (degrees)")) && categories.some(fl => fl == "Fine Learning Knock Correction (degrees)" || fl == "Fine Learning Knock Correction* (degrees)") && categories.some(el => el == "Engine Load (Calculated) (g/rev)" || el == "Engine Load* (g/rev)" || el == "Engine Load (g/rev)")){
                     let data = filteredLogs.filter(a => a.feedback_knock_corr  != 0 || a.fine_knock_corr != 0).map(b => new ScatterPoint(b.engine_speed, b.engine_load, (Math.abs(b.feedback_knock_corr + b.fine_knock_corr))*3));
                     plots.push(new PlotData(data, 'Engine Speed (rpm)', 'Engine Load (g/rev)', "Engine Load vs. Engine RPM where Knock Events Occur", "RPM", "LOAD", "TKNOCK", (x: number) => x/-3));
                 }
-                if(data.categories.some(mp => mp == "Manifold Relative Pressure (psi)")){
-                    filteredLogs = parsedLogs.filter( a=>
-                                                        a.boost >= boostFilter.value.min &&
-                                                        a.boost <= boostFilter.value.max
-                                                    );  
+                if(categories.some(mp => mp == "Manifold Relative Pressure (psi)")){
                     let data = filteredLogs.map(a => new ScatterPoint(a.engine_speed, a.boost, 5));
                     plots.push(new PlotData(data, 'Engine Speed (rpm)', 'Manifold Relative Pressure (psi)', "Manifold Relative Pressure vs. Engine RPM", "RPM", "PSI"));
                 }
-                if(data.categories.some(wg => wg == "Primary Wastegate Duty Cycle (%)")){
+                if(categories.some(wg => wg == "Primary Wastegate Duty Cycle (%)")){
                     let data = filteredLogs.map(a => new ScatterPoint(a.engine_speed, a.wastegate_duty, 5));
                     plots.push(new PlotData(data, 'Engine Speed (rpm)', "Primary Wastegate Duty Cycle (%)", "Wastegate Duty Cycle vs. Engine RPM", "RPM", "WGDC"));
                 }
-                if(data.categories.some(aem => aem == "AEM UEGO Wideband [9600 baud] (AFR Gasoline)")){
+                if(categories.some(aem => aem == "AEM UEGO Wideband [9600 baud] (AFR Gasoline)")){
                     let data = filteredLogs.map(a => new ScatterPoint(a.engine_speed, a.wideband_afr, 5));
                     plots.push(new PlotData(data, 'Engine Speed (rpm)', "AEM UEGO Wideband [9600 baud] (AFR Gasoline)", "Wideband AFR vs. Engine RPM", "RPM", "AFR"));
                 }
             }
-            clearParsedLogs();
+            //clearParsedLogs();
             plotsIndex.value += 1;
-            console.log(plots);
         }
 
         // remove data stored in ```parsedLogs```
@@ -175,6 +216,7 @@ export default defineComponent ({
         return {
             // methods
             buildObjects,
+            filterLogs,
 
             // variables
             receivedData,
@@ -184,7 +226,8 @@ export default defineComponent ({
             rpmFilter,
             loadFilter,
             boostFilter,
-        }
+            dataInfo,
+            }
     }
 
 })


### PR DESCRIPTION
1. First, I broke buildObjects() into three separate functions:

    - buildObjects(): parses output from CSVInput component into parsedLogs[] and does some other setup when a new log is received
    - filterLogs(): determines which categories exist and can be filtered on and uses this to determine which filters to show. when a new log is uploaded, this function filters the newly received logs with the default filter values. this function can also be ran on updates to the min/max value of any filter. (explained below)
    - generatePlots(): using the filtered logs created in the previous step, plots are constructed and displayed

2. The first benefit of doing this is we don't need to show the filters before logs are parsed. We can parse the logs, then depending on which categories exist, display filters for those categories. The second benefit of this is that we can make the filters reactive, meaning that any change to the min and max value of a filter once a log has been parsed can trigger the filterLogs() function and then the generatePlots() function to immediately re-render the plots based on whatever new filter value has been selected. The third benefit of this is when uploading a second file. When the second file gets uploaded, the parsedLogs[] will clear and be regenerated using the new file in buildObjects(), then filterLogs() will determine which filters should be shown for this new file and only display those, and then the new log's plots will be shown.

3. I also adding some padding to the sides of the filter box and added a counter to display how many total data points are present with the current select filters. 

(I didn't record the file select window)
![filters](https://user-images.githubusercontent.com/75876568/220813522-9c110b46-178a-496a-8a98-6440cf320f35.gif)

